### PR TITLE
Add a page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>estrannaise.js</title>
+    <title>estradiol pharmacokinetics playground - estrannaise.js</title>
 
     <link rel="icon" type="image/png" sizes="96x96" href="img/favicon-96x96.png">
     <link rel="icon" type="image/png" sizes="48x48" href="img/favicon-48x48.png">


### PR DESCRIPTION
Having the full title (estradiol pharmacokinetics playground) will help make the page a lot easier to find in browser history, if you don't remember the exact URL.