### PR TITLE
fix: display grid and ticks using 7-day interval

### DIFF
--- a/src/plotting.js
+++ b/src/plotting.js
@@ -132,6 +132,8 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
     let xMin = 0;
     let xMax = Math.max(14.1, findxMax(dataset, options));
 
+    let xInterval = 7; // 7 day week for grid and axis
+
     let dotMarks  = [],
         lineMarks = [],
         msMarks   = [],
@@ -298,7 +300,8 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
         }
     });
 
-    gridMarks.push(Plot.gridX({ stroke: 'grey' }), Plot.gridY({ stroke: 'grey' }));
+    gridMarks.push(Plot.gridX({ stroke: 'grey', interval: xInterval}), Plot.gridY({ stroke: 'grey' }));
+    gridMarks.push(Plot.axisX({ interval: xInterval }))
 
     // Vertical and horizontal lines for the y and x axes
     ruleMarks.push(Plot.ruleX([xMin]), Plot.ruleY([0]));
@@ -309,7 +312,7 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
         marginLeft: 80,
         marginBottom: 50,
         marginTop: 30,
-        x: { domain: [xMin, xMax], label: 'time (days)', ticks: 7 },
+        x: { domain: [xMin, xMax], label: 'time (days)'},
         y: { domain: [0, 1.25 * yMax], label: `serum e₂ (${units})` + (options.fudgeFactor != 1 ? ` (fudge x${options.fudgeFactor})` : ''), ticks: 6 },
         style: { fontFamily: 'monospace', fontSize: options.fontSize },
         marks: [].concat(gridMarks)


### PR DESCRIPTION
make plots more intuitive by displaying the reference grid lines and x-axis ticks on a 7 day (weekly) interval rather than the previous 10-day interval, to make reading plots more intuitive

<img width="989" alt="Screenshot 2025-03-19 at 8 14 24 PM" src="https://github.com/user-attachments/assets/eff99934-09c4-45d7-afc3-89497ace22b7" />

Reference:
fixes #53
